### PR TITLE
Adding eccentricity centrality

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,35 @@ var closeness = centrality.closeness(g);
 // }
  ```
  
+ ## [Eccentricity centrality](https://en.wikipedia.org/wiki/Distance_(graph_theory))
+
+ The eccentricity centrality of a node is the greatest distance between that node and
+ any other node in the network. It can be thought of as how far a node is from the 
+ node most distant from it in the graph.
+
+ ``` js
+var centrality = require('ngraph.centrality');
+var g = createGraph();
+g.addLink(1, 2);
+g.addLink(2, 3);
+
+var eccentricity = centrality.eccentricity(g);
+
+// eccentricity is: 
+// { 
+//   '1': 2,
+//   '2': 1,
+//   '3': 2
+// }
+ ```
+ 
+ Since the graph's diameter equals maximum eccentricity, we can easily calculate this using the returned object:
+ 
+ ```js
+ var eccentricityValues = Object.keys(eccentricity).map(function(key) {return eccentricity[key]});
+ var diameter = Math.max.apply(null, eccentricityValues);
+ // Returns 2
+ ```
 
 # install
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 module.exports.degree = require('./src/degree.js');
 module.exports.betweenness = require('./src/betweenness.js');
 module.exports.closeness = require('./src/closeness.js');
+module.exports.eccentricity = require('./src/eccentricity.js');

--- a/src/eccentricity.js
+++ b/src/eccentricity.js
@@ -28,18 +28,12 @@ function eccentricity(graph, oriented) {
   }
 
   function accumulate() {
-    // Add all distances for node to array, excluding -1s
-    var distances = Object.keys(dist).map(function(key) {return dist[key]}).filter(function(val){return val !== -1});
+    var maxDist = 0;
+    Object.keys(dist).forEach(function (key) {
+      var val = dist[key];
+      if (maxDist < val) maxDist = val;
+    });
 
-    // Get the maximum distance from this node to any other node
-    // Isolated nodes have no distances to other nodes, so set to 0 if length of distances array has no length
-    var maxDist;
-    if (distances.length) {
-      maxDist = Math.max.apply(null, distances);	
-    } else {
-      maxDist = 0;
-    }
-	
     centrality[currentNode] = maxDist;
   }
 

--- a/src/eccentricity.js
+++ b/src/eccentricity.js
@@ -1,0 +1,70 @@
+module.exports = eccentricity;
+
+/**
+ * The eccentricity centrality of a node is the greatest distance between that node and
+ * any other node in the network. 
+ */
+function eccentricity(graph, oriented) {
+  var Q = [];
+  // distance from source
+  var dist = Object.create(null);
+
+  var currentNode;
+  var centrality = Object.create(null);
+
+  graph.forEachNode(setCentralityToZero);
+  graph.forEachNode(calculateCentrality);
+
+  return centrality;
+
+  function setCentralityToZero(node) {
+    centrality[node.id] = 0;
+  }
+
+  function calculateCentrality(node) {
+    currentNode = node.id;
+    singleSourceShortestPath(currentNode);
+    accumulate();
+  }
+
+  function accumulate() {
+    // Add all distances for node to array, excluding -1s
+    var distances = Object.keys(dist).map(function(key) {return dist[key]}).filter(function(val){return val !== -1});
+
+	// Get the maximum distance from this node to any other node
+	// Isolated nodes have no distances to other nodes, so set to 0 if length of distances array has no length
+	var maxDist;
+	if (distances.length) {
+	  maxDist = Math.max.apply(null, distances);	
+	} else {
+	  maxDist = 0;
+	}
+	
+	centrality[currentNode] = maxDist;
+  }
+
+  function singleSourceShortestPath(source) {
+    graph.forEachNode(initNode);
+    dist[source] = 0;
+    Q.push(source);
+
+    while (Q.length) {
+      var v = Q.shift();
+      graph.forEachLinkedNode(v, processNode, oriented);
+    }
+
+    function initNode(node) {
+      var nodeId = node.id;
+      dist[nodeId] = -1;
+    }
+
+    function processNode(otherNode) {
+      var w = otherNode.id
+      if (dist[w] === -1) {
+        // Node w is found for the first time
+        dist[w] = dist[v] + 1;
+        Q.push(w);
+      }
+    }
+  }
+}

--- a/src/eccentricity.js
+++ b/src/eccentricity.js
@@ -31,16 +31,16 @@ function eccentricity(graph, oriented) {
     // Add all distances for node to array, excluding -1s
     var distances = Object.keys(dist).map(function(key) {return dist[key]}).filter(function(val){return val !== -1});
 
-	// Get the maximum distance from this node to any other node
-	// Isolated nodes have no distances to other nodes, so set to 0 if length of distances array has no length
-	var maxDist;
-	if (distances.length) {
-	  maxDist = Math.max.apply(null, distances);	
-	} else {
-	  maxDist = 0;
-	}
+    // Get the maximum distance from this node to any other node
+    // Isolated nodes have no distances to other nodes, so set to 0 if length of distances array has no length
+    var maxDist;
+    if (distances.length) {
+      maxDist = Math.max.apply(null, distances);	
+    } else {
+      maxDist = 0;
+    }
 	
-	centrality[currentNode] = maxDist;
+    centrality[currentNode] = maxDist;
   }
 
   function singleSourceShortestPath(source) {

--- a/test/eccentricity.js
+++ b/test/eccentricity.js
@@ -1,0 +1,16 @@
+var centrality = require('../');
+var createGraph = require('ngraph.graph');
+var test = require('tap').test;
+
+test('It finds eccentricity centrality', function(t) {
+  var g = createGraph();
+  g.addLink(1, 2);
+  g.addLink(2, 3);
+
+  var eccentricity = centrality.eccentricity(g);
+
+  t.equals(Object.keys(eccentricity).length, 3, 'Three nodes considered');
+  t.equals(eccentricity[2], 1, 'Second node eccentricity is 1');
+  t.equals(eccentricity[1], eccentricity[3], 'First and third node both have an eccentricity of 2');
+  t.end();
+});

--- a/test/eccentricity.js
+++ b/test/eccentricity.js
@@ -11,6 +11,6 @@ test('It finds eccentricity centrality', function(t) {
 
   t.equals(Object.keys(eccentricity).length, 3, 'Three nodes considered');
   t.equals(eccentricity[2], 1, 'Second node eccentricity is 1');
-  t.equals(eccentricity[1], eccentricity[3], 'First and third node both have an eccentricity of 2');
+  t.equals(eccentricity[1], eccentricity[3], 'First and third node both have the same eccentricity value (2)');
   t.end();
 });


### PR DESCRIPTION
Hi @anvaka,

This PR also adds eccentricity centrality calculations to the lib. It is based on the all-pairs shortest path and related distance calculations used for betweenness and closeness as well. 

In the readme, I also added a note that the graph's diameter can be calculated directly from the eccentricity results (since the diameter simply equals maximum eccentricity).  We could also include the diameter as a separate metric, but since it's available anyway after calculating eccentricity, I thought I'd just add it as a note there. Let me know what you think.